### PR TITLE
adding placeholder image to catalog if image source has issues

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -17,6 +17,8 @@ const mapDispatchToProps = (dispatch) => ({
     }),
 });
 
+const noImageFallback = "placeholder.png";
+
 const ItemPreview = (props) => {
   const item = props.item;
 
@@ -36,7 +38,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || noImageFallback}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
#4 
<img width="1373" alt="Screenshot 2022-12-05 at 9 26 16 PM" src="https://user-images.githubusercontent.com/104288486/205795143-f23f9821-da35-4352-9800-7097aceecb49.png">

Added a const variable of the place holder image and added conditional rendering to the image source on the catalog to show the place holder if there is none uploaded when created
