### PR TITLE
fixing the css for profile div

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,5 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  max-width: 800px;
 }


### PR DESCRIPTION
On mobile devices the header on the profile page was way too wide causing a need to side scroll which was an issue.

Fixed the css for the .user-info class of the profile name to have a max-width and not a min-width so that when the user is in mobile the header actually does size down.